### PR TITLE
fix: adjust term modal

### DIFF
--- a/app/components/TermsOfUse.tsx
+++ b/app/components/TermsOfUse.tsx
@@ -1,14 +1,15 @@
 import { Modal } from "./modal";
 import { Coluna } from "./auxiliares";
 
+const terms =
+  "Lorem ipsum dolor sit amet consectetur. Quam quis vulputate in semper tellus accumsan. Consectetur faucibus sed massa ut at. Tincidunt velit elit quis accumsan fermentum libero nisl tincidunt amet. Ut orci ac sit consectetur. Ut diam eu porttitor lacinia amet aenean. Duis aliquam viverra blandit urna amet. Lectus viverra suspendisse et tristique pulvinar nunc fringilla faucibus tincidunt. Morbi dui a dignissim magnis feugiat enim. Viverra nullam elit in magna morbi. In ac scelerisque id id lacinia eget. Facilisis fringilla tellus platea sed nunc. Id turpis egestas elementum sapien scelerisque tellus viverra amet sed. Pellentesque in lacus etiam bibendum etiam lorem eget nunc. Eget nunc pellentesque metus quam pellentesque sed ultricies. Adipiscing aenean purus metus felis ut gravida. Donec arcu iaculis neque sed dui lacinia purus imperdiet. Eu ipsum in id velit erat viverra ut. Habitasse varius volutpat rhoncus sit convallis orci. Ornare orci urna donec maecenas at. Egestas aenean sagittis imperdiet feugiat. Feugiat integer nisi leo risus sodales vel. Diam commodo nibh pretium aenean. Vestibulum curabitur dictumst aliquam tellus rutrum tincidunt eget egestas. Id orci aliquet tellus elit massa diam nam non adipiscing. Quis volutpat in diam lobortis cras. Sit augue risus et neque amet. In consequat magna dignissim tellus at. Laoreet donec duis et donec. Ullamcorper eget integer eget tellus condimentum leo diam praesent. Dictumst vivamus sem quis ipsum ut metus porttitor non. Vestibulum viverra sed diam quam. Ac augue arcu sapien sit. Viverra sit etiam a venenatis mauris nullam gravida tristique diam. Arcu urna at risus vulputate sed. Magna massa curabitur elit faucibus sem.";
+
 export const TermsOfUse = ({
   open,
   setOpen,
-  onConfirmation,
 }: {
   open: boolean;
   setOpen: (open: boolean) => void;
-  onConfirmation: () => void;
 }) => {
   return (
     <Modal open={open} setOpen={setOpen}>
@@ -16,27 +17,7 @@ export const TermsOfUse = ({
         <h1 className="font-montserrat text-3xl font-semibold text-a424A57">
           Termos e condições de uso
         </h1>
-        <h2 className="mt-6 font-montserrat text-sm font-medium text-a606771">
-          Enviamos um email com o link para fazer a mudança de senha da sua
-          conta!
-        </h2>
-        <div>
-          <input
-            id="toAgreeTerms"
-            name="toAgreeTerms"
-            type="checkbox"
-            className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-          />
-          <label htmlFor="toAgreeTerms" className="ml-2 text-sm">
-            Eu li e concordo com os termos e condições de uso.
-          </label>
-        </div>
-        <button
-          className="mt-6 w-96 rounded-md bg-a606875 py-2 font-medium text-white"
-          onClick={onConfirmation}
-        >
-          Prosseguir
-        </button>
+        <textarea value={terms} className="h-96 w-full" disabled />
       </Coluna>
     </Modal>
   );

--- a/app/components/modal.tsx
+++ b/app/components/modal.tsx
@@ -36,7 +36,7 @@ export function Modal({
               leaveFrom="opacity-100 translate-y-0 sm:scale-100"
               leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
-              <Dialog.Panel className="relative max-h-screen transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:p-6">
+              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:p-6">
                 {children}
               </Dialog.Panel>
             </Transition.Child>

--- a/app/components/modal.tsx
+++ b/app/components/modal.tsx
@@ -36,7 +36,7 @@ export function Modal({
               leaveFrom="opacity-100 translate-y-0 sm:scale-100"
               leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
-              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8   sm:p-6">
+              <Dialog.Panel className="relative max-h-screen transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:p-6">
                 {children}
               </Dialog.Panel>
             </Transition.Child>

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -152,7 +152,7 @@ export default function Login() {
           </Linha>
         </Form>
 
-        <text className=" mt-4 text-a606771">
+        <span className=" mt-4 text-a606771">
           Não tem uma conta?
           <Link
             to={{
@@ -163,7 +163,7 @@ export default function Login() {
           >
             Criar conta
           </Link>
-        </text>
+        </span>
       </Coluna>
       <CodeConfirmationModal
         open={open}

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -1,7 +1,8 @@
 import { json, redirect } from "@remix-run/node";
 import type { ActionArgs, LoaderArgs } from "@remix-run/node";
 import { Form, Link, useActionData, useSearchParams } from "@remix-run/react";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import { TermsOfUse } from "~/components/TermsOfUse";
 import { TextInput } from "~/components/TextInput";
 import { Coluna, Linha } from "~/components/auxiliares";
 import { LogoStag } from "~/components/image/icons/LogoStag";
@@ -127,6 +128,8 @@ export default function Register() {
   const emailRef = useRef<HTMLInputElement>(null);
   const passwordRef = useRef<HTMLInputElement>(null);
 
+  const [termsModalOpen, setTermsModalOpen] = useState(false);
+
   useEffect(() => {
     if (actionData?.errors?.email) {
       emailRef.current?.focus();
@@ -207,6 +210,18 @@ export default function Register() {
           >
             Criar conta
           </button>
+
+          <span className=" mt-4 text-center text-a606771">
+            Clicando em "Criar conta" você declara
+            <br /> que está ciente e concorda com nossos{" "}
+            <button
+              className="text-sky-600 underline"
+              onClick={() => setTermsModalOpen(true)}
+            >
+              termos
+            </button>
+          </span>
+
           <span className=" mt-28 text-a606771">
             Já tem uma conta?
             <Link
@@ -221,6 +236,7 @@ export default function Register() {
           </span>
         </Coluna>
       </Form>
+      <TermsOfUse open={termsModalOpen} setOpen={setTermsModalOpen} />
     </Linha>
   );
 }


### PR DESCRIPTION
- Adiciona mensagem na pagina de criar conta.
- Abre modal de termos quando clica em "termos" na mensagem
- Modifica conteúdo dos termos, pois não precisamos mais de um checkbox de confirmação.
- Renomeia `<text>` que não existe para `<span>`

![Screenshot 2023-08-18 at 14 40 52](https://github.com/azzerotec/stag/assets/9367435/32d2b54e-668b-4e55-98cf-7ced8dd5baba)
